### PR TITLE
Name branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ rails {
 - **SKIP_DEPLOY:** Do you want to skip deploying the code [String] Default: false
 - **DOWNSTREAM_JOB_NAME:** Required if DOWNSTREAM_JOB_PARAMS is not null or empty. The name of the downstream job you wish to run. [String]
 - **DOWNSTREAM_JOB_PARAMS:**  Special map of parameters and their corresponding values to pass to the downstream job. [Map]
+- **MASTER_BRANCH:** Specific what branch should assume the master branch role
+- **DEV_BRANCH:** Specific what branch should assume the dev branch role
+- **STAGE_BRANCH:** Specific what branch should assume the stage branch role
 
 ## Testing Framework Support
 

--- a/vars/rails.groovy
+++ b/vars/rails.groovy
@@ -78,6 +78,15 @@ def call(body) {
   if (config.DOWNSTREAM_JOB_PARAMS && !config.DOWNSTREAM_JOB_NAME) {
     error 'You must define DOWNSTREAM_JOB_NAME in order to use DOWNSTREAM_JOB_PARAMS'
   }
+  if (!config.MASTER_BRANCH) {
+    config.MASTER_BRANCH = "master"
+  }
+  if (!config.STAGE_BRANCH) {
+    config.MASTER_BRANCH = "stage"
+  }
+  if (!config.dev_BRANCH) {
+    config.MASTER_BRANCH = "dev"
+  }
 
 
   node {

--- a/vars/rails.groovy
+++ b/vars/rails.groovy
@@ -82,10 +82,10 @@ def call(body) {
     config.MASTER_BRANCH = "master"
   }
   if (!config.STAGE_BRANCH) {
-    config.MASTER_BRANCH = "stage"
+    config.STAGE_BRANCH = "stage"
   }
-  if (!config.dev_BRANCH) {
-    config.MASTER_BRANCH = "dev"
+  if (!config.DEV_BRANCH) {
+    config.DEV_BRANCH = "dev"
   }
 
 

--- a/vars/railsDeploy.groovy
+++ b/vars/railsDeploy.groovy
@@ -13,25 +13,25 @@ def call(Map config) {
         if (config.DEPLOY_VARS) {
           withCredentials(config.DEPLOY_VARS) {
             if (config.CAP_VERSION == '3'){
-              if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+              if (env.BRANCH_NAME == config.MASTER_BRANCH) {
                 railsRvm('cap prod deploy')
               }
-              else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+              else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
                 railsRvm('cap stage deploy')
               }
-              else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+              else if(env.BRANCH_NAME == config.DEV_BRANCH) {
                 railsRvm('cap dev deploy')
               }
               railsOtherBuildEnvs()
             }
             if (config.CAP_VERSION == '2'){
-              if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+              if (env.BRANCH_NAME == config.MASTER_BRANCH) {
                 railsRvm('cap deploy -S loc=prod')
               }
-              else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+              else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
                 railsRvm('cap deploy -S loc=stage -S branch=stage')
               }
-              else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+              else if(env.BRANCH_NAME == config.DEV_BRANCH) {
                 railsRvm('cap deploy -S loc=dev -S branch=dev')
               }
               railsOtherBuildEnvs()
@@ -40,25 +40,25 @@ def call(Map config) {
         }
         else {
           if (config.CAP_VERSION == '3'){
-            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+            if (env.BRANCH_NAME == config.MASTER_BRANCH) {
               railsRvm('cap prod deploy')
             }
-            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+            else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
               railsRvm('cap stage deploy')
             }
-            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+            else if(env.BRANCH_NAME == config.DEV_BRANCH) {
               railsRvm('cap dev deploy')
             }
             railsOtherBuildEnvs()
           }
           if (config.CAP_VERSION == '2'){
-            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+            if (env.BRANCH_NAME == config.MASTER_BRANCH) {
               railsRvm('cap deploy -S loc=prod')
             }
-            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+            else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
               railsRvm('cap deploy -S loc=stage -S branch=stage')
             }
-            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+            else if(env.BRANCH_NAME == config.DEV_BRANCH) {
               railsRvm('cap deploy -S loc=dev -S branch=dev')
             }
             railsOtherBuildEnvs()

--- a/vars/railsDeploy.groovy
+++ b/vars/railsDeploy.groovy
@@ -13,25 +13,25 @@ def call(Map config) {
         if (config.DEPLOY_VARS) {
           withCredentials(config.DEPLOY_VARS) {
             if (config.CAP_VERSION == '3'){
-              if (env.BRANCH_NAME == 'master') {
+              if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
                 railsRvm('cap prod deploy')
               }
-              else if(env.BRANCH_NAME == 'stage') {
+              else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
                 railsRvm('cap stage deploy')
               }
-              else if(env.BRANCH_NAME == 'dev') {
+              else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
                 railsRvm('cap dev deploy')
               }
               railsOtherBuildEnvs()
             }
             if (config.CAP_VERSION == '2'){
-              if (env.BRANCH_NAME == 'master') {
+              if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
                 railsRvm('cap deploy -S loc=prod')
               }
-              else if(env.BRANCH_NAME == 'stage') {
+              else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
                 railsRvm('cap deploy -S loc=stage -S branch=stage')
               }
-              else if(env.BRANCH_NAME == 'dev') {
+              else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
                 railsRvm('cap deploy -S loc=dev -S branch=dev')
               }
               railsOtherBuildEnvs()
@@ -40,25 +40,25 @@ def call(Map config) {
         }
         else {
           if (config.CAP_VERSION == '3'){
-            if (env.BRANCH_NAME == 'master') {
+            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
               railsRvm('cap prod deploy')
             }
-            else if(env.BRANCH_NAME == 'stage') {
+            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
               railsRvm('cap stage deploy')
             }
-            else if(env.BRANCH_NAME == 'dev') {
+            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
               railsRvm('cap dev deploy')
             }
             railsOtherBuildEnvs()
           }
           if (config.CAP_VERSION == '2'){
-            if (env.BRANCH_NAME == 'master') {
+            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
               railsRvm('cap deploy -S loc=prod')
             }
-            else if(env.BRANCH_NAME == 'stage') {
+            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
               railsRvm('cap deploy -S loc=stage -S branch=stage')
             }
-            else if(env.BRANCH_NAME == 'dev') {
+            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
               railsRvm('cap deploy -S loc=dev -S branch=dev')
             }
             railsOtherBuildEnvs()

--- a/vars/railsDeployDocker.groovy
+++ b/vars/railsDeployDocker.groovy
@@ -12,25 +12,25 @@ def call(Map config) {
       if (config.DEPLOY_VARS) {
         withCredentials(config.DEPLOY_VARS) {
           if (config.CAP_VERSION == '3'){
-            if (env.BRANCH_NAME == 'master') {
+            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
               sh "${config.container} cap prod deploy"
             }
-            else if(env.BRANCH_NAME == 'stage') {
+            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
               sh "${config.container} cap stage deploy"
             }
-            else if(env.BRANCH_NAME == 'dev') {
+            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
               sh "${config.container} cap dev deploy"
             }
             railsOtherBuildEnvsDocker(config)
           }
           if (config.CAP_VERSION == '2'){
-            if (env.BRANCH_NAME == 'master') {
+            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
               sh "${config.container} cap deploy -S loc=prod"
             }
-            else if(env.BRANCH_NAME == 'stage') {
+            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
               sh "${config.container} cap deploy -S loc=stage -S branch=stage"
             }
-            else if(env.BRANCH_NAME == 'dev') {
+            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
               sh "${config.container} cap deploy -S loc=dev -S branch=dev"
             }
             railsOtherBuildEnvsDocker(config)
@@ -39,25 +39,25 @@ def call(Map config) {
       }
       else {
         if (config.CAP_VERSION == '3'){
-          if (env.BRANCH_NAME == 'master') {
+          if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
             sh "${config.container} cap prod deploy"
           }
-          else if(env.BRANCH_NAME == 'stage') {
+          else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
             sh "${config.container} cap stage deploy"
           }
-          else if(env.BRANCH_NAME == 'dev') {
+          else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
             sh "${config.container} cap dev deploy"
           }
           railsOtherBuildEnvsDocker(config)
         }
         if (config.CAP_VERSION == '2'){
-          if (env.BRANCH_NAME == 'master') {
+          if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
             sh "${config.container} cap deploy -S loc=prod"
           }
-          else if(env.BRANCH_NAME == 'stage') {
+          else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
             sh "${config.container} cap deploy -S loc=stage -S branch=stage"
           }
-          else if(env.BRANCH_NAME == 'dev') {
+          else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
             sh "${config.container} cap deploy -S loc=dev -S branch=dev"
           }
           railsOtherBuildEnvsDocker(config)

--- a/vars/railsDeployDocker.groovy
+++ b/vars/railsDeployDocker.groovy
@@ -12,25 +12,25 @@ def call(Map config) {
       if (config.DEPLOY_VARS) {
         withCredentials(config.DEPLOY_VARS) {
           if (config.CAP_VERSION == '3'){
-            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+            if (env.BRANCH_NAME == config.MASTER_BRANCH) {
               sh "${config.container} cap prod deploy"
             }
-            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+            else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
               sh "${config.container} cap stage deploy"
             }
-            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+            else if(env.BRANCH_NAME == config.DEV_BRANCH) {
               sh "${config.container} cap dev deploy"
             }
             railsOtherBuildEnvsDocker(config)
           }
           if (config.CAP_VERSION == '2'){
-            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+            if (env.BRANCH_NAME == config.MASTER_BRANCH) {
               sh "${config.container} cap deploy -S loc=prod"
             }
-            else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+            else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
               sh "${config.container} cap deploy -S loc=stage -S branch=stage"
             }
-            else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+            else if(env.BRANCH_NAME == config.DEV_BRANCH) {
               sh "${config.container} cap deploy -S loc=dev -S branch=dev"
             }
             railsOtherBuildEnvsDocker(config)
@@ -39,25 +39,25 @@ def call(Map config) {
       }
       else {
         if (config.CAP_VERSION == '3'){
-          if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+          if (env.BRANCH_NAME == config.MASTER_BRANCH) {
             sh "${config.container} cap prod deploy"
           }
-          else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+          else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
             sh "${config.container} cap stage deploy"
           }
-          else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+          else if(env.BRANCH_NAME == config.DEV_BRANCH) {
             sh "${config.container} cap dev deploy"
           }
           railsOtherBuildEnvsDocker(config)
         }
         if (config.CAP_VERSION == '2'){
-          if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH) {
+          if (env.BRANCH_NAME == config.MASTER_BRANCH) {
             sh "${config.container} cap deploy -S loc=prod"
           }
-          else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == config.STAGE_BRANCH) {
+          else if(env.BRANCH_NAME == config.STAGE_BRANCH) {
             sh "${config.container} cap deploy -S loc=stage -S branch=stage"
           }
-          else if(env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH) {
+          else if(env.BRANCH_NAME == config.DEV_BRANCH) {
             sh "${config.container} cap deploy -S loc=dev -S branch=dev"
           }
           railsOtherBuildEnvsDocker(config)

--- a/vars/railsRvm.groovy
+++ b/vars/railsRvm.groovy
@@ -6,10 +6,10 @@
 #!/usr/bin/env groovy
 
 def call(String commands) {
-  if(env.BRANCH_NAME == 'master'){
+  if(env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH){
     sh "bash -c \"source /usr/local/rvm/scripts/rvm && rvm use --install --create ${env.RUBY_VERSION}@${env.RUBY_GEMSET} && ${commands}\""
   }
-  else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == 'dev'){
+  else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH || env.BRANCH_NAME == config.STAGE_BRANCH){
     sh "bash -c \"source /usr/local/rvm/scripts/rvm && rvm use --install --create ${env.RUBY_VERSION}@${env.BRANCH_NAME}-${env.RUBY_GEMSET} && ${commands}\""
   }
   else if (env.BRANCH_NAME == /PR-.*/) {

--- a/vars/railsRvm.groovy
+++ b/vars/railsRvm.groovy
@@ -6,10 +6,10 @@
 #!/usr/bin/env groovy
 
 def call(String commands) {
-  if(env.BRANCH_NAME == 'master' || env.BRANCH_NAME == config.MASTER_BRANCH){
+  if(env.BRANCH_NAME == config.MASTER_BRANCH){
     sh "bash -c \"source /usr/local/rvm/scripts/rvm && rvm use --install --create ${env.RUBY_VERSION}@${env.RUBY_GEMSET} && ${commands}\""
   }
-  else if(env.BRANCH_NAME == 'stage' || env.BRANCH_NAME == 'dev' || env.BRANCH_NAME == config.DEV_BRANCH || env.BRANCH_NAME == config.STAGE_BRANCH){
+  else if(env.BRANCH_NAME == config.DEV_BRANCH || env.BRANCH_NAME == config.STAGE_BRANCH){
     sh "bash -c \"source /usr/local/rvm/scripts/rvm && rvm use --install --create ${env.RUBY_VERSION}@${env.BRANCH_NAME}-${env.RUBY_GEMSET} && ${commands}\""
   }
   else if (env.BRANCH_NAME == /PR-.*/) {


### PR DESCRIPTION
# Summary

### Problem: 

Sometimes branches don't use standard names like 'master', 'stage' and 'dev'. And the application can't be dealing only with these threes names.

### Features developed:

- Branches name set in enviroment variables 

## Branches name

Now, we can set in Jenkinfile the environment variables MASTER_BRANCH, STAGE_BRANCH, DEV_BRANCH to specic what branch should assuming this roles. Case this variables is empty, it values will be 'master', 'stage' and 'dev' respectively
